### PR TITLE
feat: Shader Graph WGSL eaiser to study/debug wgsl

### DIFF
--- a/webgpu/lessons/webgpu-resources.md
+++ b/webgpu/lessons/webgpu-resources.md
@@ -19,6 +19,7 @@ Here are some other webgpu resources
 * [WebGPU Shadow Playground](https://toji.github.io/webgpu-shadow-playground/)
 * [WebGPU Metaballs](https://toji.github.io/webgpu-metaballs/)
 * [Shadertoy example in WebGPU](https://jsgist.org/?src=a17b03b88c86c08ac621298dae50e30b)
+* [Shader Graph WGSL](https://deepkolos.github.io/shader-graph-wgsl/)
 
 # Tools
 


### PR DESCRIPTION
add a WGSL Shader Graph playground link, which maybe helpful to study/debug wgsl shader

repo: https://github.com/deepkolos/shader-graph-wgsl
demo: https://deepkolos.github.io/shader-graph-wgsl/

<img width="1344" alt="dissolve" src="https://user-images.githubusercontent.com/12824616/236374315-aebcd0b6-7837-4a31-b5b0-46625687e3ae.png">

<img width="1344" alt="fresnelOutline" src="https://user-images.githubusercontent.com/12824616/236374340-7bbcbf8e-486f-4dd9-92d0-aa28ab458c88.png">

