### PR TITLE
Minor fixes in the code examples.

### DIFF
--- a/webgpu/lessons/webgpu-fundamentals.md
+++ b/webgpu/lessons/webgpu-fundamentals.md
@@ -235,7 +235,7 @@ a device.
 
 ```js
 async function main() {
-  const adapter = await gpu?.requestAdapter();
+  const adapter = await navigator.gpu?.requestAdapter();
   const device = await adapter?.requestDevice();
   if (!device) {
     fail('need a browser that supports WebGPU');

--- a/webgpu/lessons/webgpu-importing-textures.md
+++ b/webgpu/lessons/webgpu-importing-textures.md
@@ -600,7 +600,7 @@ on `videoWidth` and `videoHeight`. So, let's update the code to handle that diff
     device.queue.copyExternalImageToTexture(
       { source, flipY, },
       { texture },
-      { width: source.width, height: source.height },
+-      { width: source.width, height: source.height },
 +      getSourceSize(source),
     );
 

--- a/webgpu/lessons/webgpu-importing-textures.md
+++ b/webgpu/lessons/webgpu-importing-textures.md
@@ -580,7 +580,7 @@ Here's a video
 
 <div class="webgpu_center">
   <div>
-     <video mute controls src="../resources/videos/Golden_retriever_swimming_the_doggy_paddle-360-no-audio.webm" style="width: 720px";></video>
+     <video muted controls src="../resources/videos/Golden_retriever_swimming_the_doggy_paddle-360-no-audio.webm" style="width: 720px";></video>
      <div class="copyright"><a href="https://commons.wikimedia.org/wiki/File:Golden_retriever_swimming_the_doggy_paddle.webm">CC-BY: Golden Woofs</a></div>
   </div>
 </div>
@@ -630,7 +630,7 @@ So then, lets setup a video element
 
 ```js
   const video = document.createElement('video');
-  video.mute = true;
+  video.muted = true;
   video.loop = true;
   video.preload = 'auto';
   video.src = 'resources/videos/Golden_retriever_swimming_the_doggy_paddle-360-no-audio.webm';
@@ -678,7 +678,7 @@ sadly, old browsers made it hard to know when it's safe to use a video 😅
 +  }
 
   const video = document.createElement('video');
-  video.mute = true;
+  video.muted = true;
   video.loop = true;
   video.preload = 'auto';
   video.src = 'resources/videos/Golden_retriever_swimming_the_doggy_paddle-360-no-audio.webm';
@@ -739,7 +739,7 @@ Then let's write a function to wait for it to be clicked and hide it.
 +  }
 
   const video = document.createElement('video');
-  video.mute = true;
+  video.muted = true;
   video.loop = true;
   video.preload = 'auto';
   video.src = 'resources/videos/Golden_retriever_swimming_the_doggy_paddle-360-no-audio.webm';
@@ -760,7 +760,7 @@ For example
 
 ```js
   const video = document.createElement('video');
-  video.mute = true;
+  video.muted = true;
   video.loop = true;
   video.preload = 'auto';
   video.src = 'resources/videos/Golden_retriever_swimming_the_doggy_paddle-360-no-audio.webm';

--- a/webgpu/lessons/webgpu-vertex-buffers.md
+++ b/webgpu/lessons/webgpu-vertex-buffers.md
@@ -67,7 +67,7 @@ As you can see, it's a small change. We declared a struct `Vertex` to define the
 for a vertex. The important part is declaring the position field with `@location(0)`
 
 Then, when we create the render pipeline, we have to tell WebGPU how to get data
-for `@location0`
+for `@location(0)`
 
 ```js
   const pipeline = device.createRenderPipeline({

--- a/webgpu/webgpu-simple-textured-quad-import-video.html
+++ b/webgpu/webgpu-simple-textured-quad-import-video.html
@@ -298,7 +298,7 @@ async function main() {
   }
 
   const video = document.createElement('video');
-  video.mute = true;
+  video.muted = true;
   video.loop = true;
   video.preload = 'auto';
   video.src = 'resources/videos/Golden_retriever_swimming_the_doggy_paddle-360-no-audio.webm'; /* webgpufundamentals: url */


### PR DESCRIPTION
Some minor fixes of problems I caught while implementing the examples.

* Adds a missing `navigator` on a `gpu.requestAdapter` call
* Changes `mute` to `muted` since `mute` is not valid ([WebIDL link](https://hg.mozilla.org/mozilla-central/file/tip/dom/webidl/HTMLMediaElement.webidl))
* Fix a diff in a `copyExternalImageToTexture` example 
* Fix a typo on an `@location` reference