### PR TITLE
feat: add wgsl-struct-buffer link

### DIFF
--- a/webgpu/lessons/webgpu-resources.md
+++ b/webgpu/lessons/webgpu-resources.md
@@ -36,7 +36,7 @@ Here are some other webgpu resources
 ## Utilities
 
 * [webgpu-utils](https://github.com/greggman/webgpu-utils) - helps set uniform buffer data and more
-
+* [wgsl-struct-buffer](https://github.com/deepkolos/wgsl-struct-buffer) - wgsl's struct buffer view in ts with type check & infer
 
 
 


### PR DESCRIPTION
another helper to interact with wgsl's struct buffer, which is ts object map wgsl struct

https://github.com/deepkolos/wgsl-struct-buffer

```ts
import { wgsl } from 'wgsl-struct-buffer';

const { view, buffer, struct } = new wgsl.StructBuffer({
  ambient: 'vec3f', // vec{2,3,4}{f,h,u,i}
  lightCount: 'u32', // f32, f16, u32, i32
  lights: [
    {
      position: 'vec3f',
      range: 'f32',
      color: 'vec3f',
      intensity: 'f32',
    },
    4,
  ],
});
view.ambient.set([0, 0, 0]);
view.lightCount = 4;
view.lights.forEach(light => {
  light.position.set([1, 2, 3]);
  light.color.set([1, 1, 1]);
  light.range = 10;
  light.intensity = 0.8;
});
console.log(buffer);
console.log(wgsl.stringifyStruct('LightInfo', struct));
/** output
struct LightInfo_lights {
  position: vec3f,
  range: f32,
  color: vec3f,
  intensity: f32,
};
struct LightInfo {
  ambient: vec3f,
  lightCount: u32,
  lights: array<LightInfo_lights, 4>,
};
*/
```