### PR TITLE
Add missing diff markers for the position getter

### DIFF
--- a/webgpu/lessons/webgpu-storage-buffers.md
+++ b/webgpu/lessons/webgpu-storage-buffers.md
@@ -343,7 +343,8 @@ struct VSOutput {
 
   var vsOut: VSOutput;
   vsOut.position = vec4f(
-      pos[vertexIndex].position * otherStruct.scale + ourStruct.offset, 0.0, 1.0);
+-      pos[vertexIndex] * otherStruct.scale + ourStruct.offset, 0.0, 1.0);
++      pos[vertexIndex].position * otherStruct.scale + ourStruct.offset, 0.0, 1.0);
   vsOut.color = ourStruct.color;
   return vsOut;
 }


### PR DESCRIPTION
This line was changed from the previous shader, but was not marked.