### PR TITLE
Reduce vertex buffer size when only 8-bit colors

### DIFF
--- a/webgpu/lessons/webgpu-vertex-buffers.md
+++ b/webgpu/lessons/webgpu-vertex-buffers.md
@@ -377,9 +377,13 @@ function createCircleVertices({
   startAngle = 0,
   endAngle = Math.PI * 2,
 } = {}) {
-  // 2 triangles per subdivision, 3 verts per tri, 5 values (xyrgb) each.
+-  // 2 triangles per subdivision, 3 verts per tri, 5 values (xyrgb) each.
++  // 2 triangles per subdivision, 3 verts per tri
   const numVertices = numSubdivisions * 3 * 2;
-  const vertexData = new Float32Array(numVertices * (2 + 3));
+-  const vertexData = new Float32Array(numVertices * (2 + 3));
++  // 2 32-bit values for position (xy) and 1 32-bit value for color (rgb)
++  // The 32-bit color value will be written/read as 4 8-bit values
++  const vertexData = new Float32Array(numVertices * (2 + 1));
 +  const colorData = new Uint8Array(vertexData.buffer);
 
   let offset = 0;

--- a/webgpu/webgpu-vertex-buffers-2-attributes-8bit-colors.html
+++ b/webgpu/webgpu-vertex-buffers-2-attributes-8bit-colors.html
@@ -40,9 +40,11 @@ function createCircleVertices({
   startAngle = 0,
   endAngle = Math.PI * 2,
 } = {}) {
-  // 2 triangles per subdivision, 3 verts per tri, 5 values (xyrgb) each.
+  // 2 triangles per subdivision, 3 verts per tri
   const numVertices = numSubdivisions * 3 * 2;
-  const vertexData = new Float32Array(numVertices * (2 + 3));
+  // 2 32-bit values for position (xy) and 1 32-bit value for color (rgb)
+  // The 32-bit color value will be written/read as 4 8-bit values
+  const vertexData = new Float32Array(numVertices * (2 + 1));
   const colorData = new Uint8Array(vertexData.buffer);
 
   let offset = 0;


### PR DESCRIPTION
- Vertex buffer was still being sized with 3 32-bit floats for color in mind.

I thought it was slightly confusing that the size of the vertex buffer did not change when you reduced the storage requirements per vertex.