### PR TITLE
Fix code change in the createCircleVertices function in webgpu-vertex-buffers.md

### DIFF
--- a/webgpu/lessons/webgpu-vertex-buffers.md
+++ b/webgpu/lessons/webgpu-vertex-buffers.md
@@ -953,10 +953,10 @@ function createCircleVertices({
 +  }
 
   return {
-    positionData,
-    colorData,
+    vertexData,
 +    indexData,
-    numVertices: indexData.length,
+-    numVertices,
++    numVertices: indexData.length,
   };
 }
 ```


### PR DESCRIPTION
The return value of createCircleVertices was as follows:
```javascript
return {
    positionData,
    colorData,
    indexData,
    numVertices: indexData.length,
};
```
However, it should be as follows:
```javascript
return {
  vertexData,
  indexData,
  numVertices: indexData.length
};
```